### PR TITLE
Disable var everywhere error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,7 @@ dotnet_style_explicit_tuple_names = true:error
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = true:error
-csharp_style_var_elsewhere = true
+csharp_style_var_elsewhere = true:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,7 @@ dotnet_style_explicit_tuple_names = true:error
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = true:error
-csharp_style_var_elsewhere = false
+csharp_style_var_elsewhere = true
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,7 @@ dotnet_style_explicit_tuple_names = true:error
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = true:error
-csharp_style_var_elsewhere = true:error
+csharp_style_var_elsewhere = false
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none


### PR DESCRIPTION
To improve code readability and support writing, I suggest we refrain from using `var` **everywhere**. 
In some cases it is better to declare the explicit type, and for these cases I suggest we **should** declare it, without receiving compile errors. 
We are still free to use `var` wherever we like, this change just prevents throwing errors when we judge an explicit type to be fitting.