### PR TITLE
Built-in-types readability, prefer not-var

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,7 +50,7 @@ dotnet_style_explicit_tuple_names = true:error
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:error
+csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_elsewhere = true:error
 


### PR DESCRIPTION
For readability of code, personally I like working with explicitly typed built-in-types instead of using var for those. 
For those who still prefer "var" for built-in-types, they will only get a **suggestion** to use explicit.

I think it would be good if we yay/nay this one so we can do a headcount of preference.

To clarify this will change the suggested behavior from:

```
var myAge = 1;
var firstName = "Hello";
var newCustomer = new Customer();
ReturnToMeSomething(out var pullRequestCreationDate);
```

To:


```
int myAge = 1;
string firstName = "Hello";
var newCustomer = new Customer();
ReturnToMeSomething(out var pullRequestCreationDate);
```


