### PR TITLE
Data Annotation Validation

### DIFF
--- a/NETDefault/Libs/REAME.md
+++ b/NETDefault/Libs/REAME.md
@@ -1,0 +1,5 @@
+# Libs
+
+This folder contains small and useful code that can be used in projects. These things are probably too small for a NuGet package, which also makes them harder to use as they cannot be tweaked for the projects requirements.
+
+DO NOT copy this entire libs folder into a project "because it can be useful" like an uncivilized cargo-cult coder; take only what you need. 

--- a/NETDefault/Libs/Triple.DataAnnotations/CompositeValidationResult.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/CompositeValidationResult.cs
@@ -9,10 +9,5 @@ namespace Triple.DataAnnotations
         public List<ValidationResult> Results { get; private set; } = new List<ValidationResult>();
 
         public CompositeValidationResult(string errorMessage, string? memberName = default) : base(errorMessage) { MemberName = memberName; }
-
-        public void AddResult(ValidationResult validationResult)
-        {
-            Results.Add(validationResult);
-        }
     }
 }

--- a/NETDefault/Libs/Triple.DataAnnotations/CompositeValidationResult.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/CompositeValidationResult.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Triple.DataAnnotations
+{
+    public class CompositeValidationResult : ValidationResult
+    {
+        public string? MemberName { get; private set; }
+        public List<ValidationResult> Results { get; private set; } = new List<ValidationResult>();
+
+        public CompositeValidationResult(string errorMessage, string? memberName = default) : base(errorMessage) { MemberName = memberName; }
+
+        public void AddResult(ValidationResult validationResult)
+        {
+            Results.Add(validationResult);
+        }
+    }
+}

--- a/NETDefault/Libs/Triple.DataAnnotations/Triple.DataAnnotations.csproj
+++ b/NETDefault/Libs/Triple.DataAnnotations/Triple.DataAnnotations.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/NETDefault/Libs/Triple.DataAnnotations/ValidateEnumerableAttribute.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/ValidateEnumerableAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Triple.DataAnnotations
+{
+    /// <summary>
+    /// This attribute will instruct the entity validator to also validate each of the elements of this enumerable, instead of just the enumerable itself.
+    /// </summary>
+    public class ValidateEnumerableAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value == null)
+            {
+                return ValidationResult.Success!;
+            }
+
+            if (value is not IEnumerable enumerable)
+            {
+                return new ValidationResult($"{nameof(ValidateEnumerableAttribute)} can only be used on IEnumerable's");
+            }
+
+            var results = new List<ValidationResult>();
+
+            foreach (var item in enumerable)
+            {
+                var context = new ValidationContext(item, validationContext, null);
+
+                Validator.TryValidateObject(item, context, results, true);
+            }
+
+            var compositeResults = new CompositeValidationResult($"Validation for {validationContext.DisplayName} failed!", validationContext.MemberName ?? "Unknown member");
+            if (results.Count != 0)
+            {
+                results.ForEach(compositeResults.AddResult);
+                return compositeResults;
+            }
+
+            return ValidationResult.Success!;
+        }
+    }
+}

--- a/NETDefault/Libs/Triple.DataAnnotations/ValidateEnumerableAttribute.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/ValidateEnumerableAttribute.cs
@@ -9,11 +9,11 @@ namespace Triple.DataAnnotations
     /// </summary>
     public class ValidateEnumerableAttribute : ValidationAttribute
     {
-        protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             if (value == null)
             {
-                return ValidationResult.Success!;
+                return ValidationResult.Success;
             }
 
             if (value is not IEnumerable enumerable)
@@ -33,11 +33,11 @@ namespace Triple.DataAnnotations
             var compositeResults = new CompositeValidationResult($"Validation for {validationContext.DisplayName} failed!", validationContext.MemberName ?? "Unknown member");
             if (results.Count != 0)
             {
-                results.ForEach(compositeResults.AddResult);
+                compositeResults.Results.AddRange(results);
                 return compositeResults;
             }
 
-            return ValidationResult.Success!;
+            return ValidationResult.Success;
         }
     }
 }

--- a/NETDefault/Libs/Triple.DataAnnotations/ValidateObjectAttribute.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/ValidateObjectAttribute.cs
@@ -8,11 +8,11 @@ namespace Triple.DataAnnotations
     /// </summary>
     public class ValidateObjectAttribute : ValidationAttribute
     {
-        protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             if (value == null)
             {
-                return ValidationResult.Success!;
+                return ValidationResult.Success;
             }
 
             var results = new List<ValidationResult>();
@@ -23,12 +23,12 @@ namespace Triple.DataAnnotations
             if (results.Count != 0)
             {
                 var compositeResults = new CompositeValidationResult($"Validation for {validationContext.DisplayName} failed!", validationContext.MemberName ?? "Unknown member");
-                results.ForEach(compositeResults.AddResult);
+                compositeResults.Results.AddRange(results);
 
                 return compositeResults;
             }
 
-            return ValidationResult.Success!;
+            return ValidationResult.Success;
         }
     }
 }

--- a/NETDefault/Libs/Triple.DataAnnotations/ValidateObjectAttribute.cs
+++ b/NETDefault/Libs/Triple.DataAnnotations/ValidateObjectAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Triple.DataAnnotations
+{
+    /// <summary>
+    /// This attribute will instruct the entity validator to also validate the properties of this object, instead of just the object itself.
+    /// </summary>
+    public class ValidateObjectAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value == null)
+            {
+                return ValidationResult.Success!;
+            }
+
+            var results = new List<ValidationResult>();
+            var context = new ValidationContext(value, validationContext, null);
+
+            Validator.TryValidateObject(value, context, results, true);
+
+            if (results.Count != 0)
+            {
+                var compositeResults = new CompositeValidationResult($"Validation for {validationContext.DisplayName} failed!", validationContext.MemberName ?? "Unknown member");
+                results.ForEach(compositeResults.AddResult);
+
+                return compositeResults;
+            }
+
+            return ValidationResult.Success!;
+        }
+    }
+}

--- a/NETDefault/NETDefault.sln
+++ b/NETDefault/NETDefault.sln
@@ -15,8 +15,13 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionAppNETCore31", "FunctionAppNETCore31\FunctionAppNETCore31.csproj", "{F4F69FAD-55D4-4BB4-9374-BA3D4F993D53}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libs", "Libs", "{3B338A95-0EBC-49D1-9E3A-D793FB928F6B}"
+	ProjectSection(SolutionItems) = preProject
+		Libs\REAME.md = Libs\REAME.md
+	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Triple.Extensions.Options", "Libs\Triple.Extensions.Options\Triple.Extensions.Options.csproj", "{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triple.Extensions.Options", "Libs\Triple.Extensions.Options\Triple.Extensions.Options.csproj", "{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Triple.DataAnnotations", "Libs\Triple.DataAnnotations\Triple.DataAnnotations.csproj", "{5A2CB20C-4DA7-4A23-BCD3-7840714B1753}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,12 +45,17 @@ Global
 		{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A2CB20C-4DA7-4A23-BCD3-7840714B1753}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A2CB20C-4DA7-4A23-BCD3-7840714B1753}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A2CB20C-4DA7-4A23-BCD3-7840714B1753}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A2CB20C-4DA7-4A23-BCD3-7840714B1753}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{66F585E9-EA6D-4BC4-AFFB-3DD5D32A34A0} = {3B338A95-0EBC-49D1-9E3A-D793FB928F6B}
+		{5A2CB20C-4DA7-4A23-BCD3-7840714B1753} = {3B338A95-0EBC-49D1-9E3A-D793FB928F6B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5486E77-E6A0-4398-9683-B4BF44008D49}

--- a/Patterns/Validation.md
+++ b/Patterns/Validation.md
@@ -1,0 +1,14 @@
+# Validation
+
+## Data Annotation Validators
+
+Validating data using Data Annotation Validators is a simple but powerful way of validating incoming data or settings. It provides a convenient amount of validators that can be assigned to properties using attributes. 
+
+```c#
+public class Data 
+{
+    [MinLength(10)]
+    public string? Name { get; set; }
+}
+```
+

--- a/Patterns/Validation.md
+++ b/Patterns/Validation.md
@@ -2,13 +2,46 @@
 
 ## Data Annotation Validators
 
-Validating data using Data Annotation Validators is a simple but powerful way of validating incoming data or settings. It provides a convenient amount of validators that can be assigned to properties using attributes. 
+Validating data using [Data Annotation Validators](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations?view=net-5.0) is a simple but powerful way of validating incoming data or settings. It provides a convenient amount of validators that can be assigned to properties using attributes. 
 
 ```c#
 public class Data 
 {
     [MinLength(10)]
     public string? Name { get; set; }
+
+    [Required]
+    public IEnumerable<Data> Children { get; set; }
+
+    [Required]
+    public Data Parent { get; set; }
 }
 ```
 
+When using Data Annotation Validators please keep in mind:
+
+- Use `[Required]` to make an property required. `null` is a valid value for `[MinLength(10)]` as it ignores `null`.
+- Nested objects (like Parent) and arrays (like Children) are not validated (see below).
+- Data Annotation Validators are sync only. If `async` is required, use something like `FluentValidation`. Keep in mind that `ASP.NET Core` will always validate sync, `async` validation should always be implemented inside a controller.
+
+### Validating nested objects and arrays
+
+Data Annotation Validators validate the property, not the object within the property. The validating `Data` in the example above will not validate `Children`, but only the array of `Children`. If that property has `[MaxLength(2)]`, the amount of children are validated, but every child can be invalid. To validate deeper into the graph, update the `Data` model as follows:
+
+```c#
+public class Data 
+{
+    [MinLength(10)]
+    public string? Name { get; set; }
+
+    [Required]
+    [ValidateEnumerable]
+    public IEnumerable<Data> Children { get; set; }
+
+    [Required]
+    [ValidateObject]
+    public Data Parent { get; set; }
+}
+```
+
+The `[ValidateEnumerable]` and `[ValidateObject]` attributes instruct the validator to go into the enumerable or object. Error messages from the deeper properties are grouped under the error message of the `Children` and `Parent` properties. The implementation of these attributes can be found in NETDefault/Libs/Triple.DataAnnotations.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Common boilerplate, practices, and guidelines for Triple .NET projects.
 
 - [Request cancellation](Patterns/CancelRequest.md)
 - [Hosted service](Patterns/HostedServices.md)
+- [Data Annotation Validation](Patterns/Validation.md)
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)].
 


### PR DESCRIPTION
Fixes #28 

- [x] Remove `!` from `ValidationResult.Success!` and make nullable.