### PR TITLE
Added example of unit tests using moq and Mock Objects

### DIFF
--- a/NETDefault/UnitTestingWithNUnit&Moq/HobbiesTestCases.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/HobbiesTestCases.cs
@@ -7,9 +7,6 @@ namespace UnitTestingExample
     {
         public IEnumerator GetEnumerator()
         {
-            yield return new TestCaseData(null, ", hobbies error")
-                .SetName($"{nameof(UserServiceTests.GetDashboard_WhenHobbiesFound_ItShouldBeReturned)}(null)");
-
             yield return new TestCaseData(new string[0] { }, ", zero hobbies")
                 .SetName($"{nameof(UserServiceTests.GetDashboard_WhenHobbiesFound_ItShouldBeReturned)}(zero hobbies)");
 

--- a/NETDefault/UnitTestingWithNUnit&Moq/MockLogger.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/MockLogger.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace UnitTestingExample;
+
+internal sealed class MockLogger : Mock<ILogger<UserService>>
+{
+    private MockLogger(string expectedLogMessage)
+    {
+        Setup(x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString() == expectedLogMessage),
+                It.IsAny<NotFoundException>(),
+                It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)!))
+            .Verifiable();
+    }
+    
+    public static MockLogger Create(string expectedLogMessage) =>
+        new (expectedLogMessage);
+}

--- a/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
@@ -4,7 +4,7 @@ namespace UnitTestingExample;
 
 internal sealed class MockUserGateway : Mock<IUserGateway>
 {
-    private MockUserGateWay(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null)
+    private MockUserGateway(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null)
     {
         if (userId == null)
         {
@@ -25,6 +25,6 @@ internal sealed class MockUserGateway : Mock<IUserGateway>
             .Returns(notificationCount);
     }
     
-    public static MockUserGateWay Create(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null) =>
+    public static MockUserGateway Create(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null) =>
         new (userName, userId, hobbies, notificationCount);
 }

--- a/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
@@ -1,0 +1,30 @@
+﻿using Moq;
+
+namespace UnitTestingExample;
+
+internal sealed class MockUserGateWay : Mock<IUserGateway>
+{
+    private MockUserGateWay(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null)
+    {
+        if (userId == null)
+        {
+            Setup(x => x.GetUserIdByUserName(userName))
+                .Throws<NotFoundException>();
+        }
+        else
+        {
+            Setup(x => x.GetUserIdByUserName(userName))
+                .Returns(userId.Value);
+        
+        }
+
+        Setup(x => x.GetHobbiesByUserId(userId ?? -1))
+            .Returns(hobbies!);
+
+        Setup(x => x.GetNotificationsByUserId(userId ?? -1))
+            .Returns(notificationCount);
+    }
+    
+    public static MockUserGateWay Create(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null) =>
+        new (userName, userId, hobbies, notificationCount);
+}

--- a/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
@@ -15,14 +15,15 @@ internal sealed class MockUserGateway : Mock<IUserGateway>
         {
             Setup(x => x.GetUserIdByUserName(userName))
                 .Returns(userId.Value);
-        
+            
+            Setup(x => x.GetHobbiesByUserId(userId.Value))
+                .Returns(hobbies!);
+
+            Setup(x => x.GetNotificationsByUserId(userId.Value))
+                .Returns(notificationCount);
         }
 
-        Setup(x => x.GetHobbiesByUserId(userId ?? -1))
-            .Returns(hobbies!);
-
-        Setup(x => x.GetNotificationsByUserId(userId ?? -1))
-            .Returns(notificationCount);
+        
     }
     
     public static MockUserGateway Create(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null) =>

--- a/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/MockUserGateWay.cs
@@ -2,7 +2,7 @@
 
 namespace UnitTestingExample;
 
-internal sealed class MockUserGateWay : Mock<IUserGateway>
+internal sealed class MockUserGateway : Mock<IUserGateway>
 {
     private MockUserGateWay(string userName, int? userId = null, string[]? hobbies = null, int? notificationCount = null)
     {

--- a/NETDefault/UnitTestingWithNUnit&Moq/UnitTestingExample.csproj
+++ b/NETDefault/UnitTestingWithNUnit&Moq/UnitTestingExample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 

--- a/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTests.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTests.cs
@@ -8,9 +8,9 @@ namespace UnitTestingExample
 {
     internal class UserServiceTests
     {
-        private UserService _subject;
-        private Mock<IUserGateway> _gateway;
-        private Mock<ILogger<UserService>> _logger;
+        private UserService _subject = default!;
+        private Mock<IUserGateway> _gateway  = default!;
+        private Mock<ILogger<UserService>> _logger = default!;
 
         [SetUp]
         public void Setup()

--- a/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTests.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTests.cs
@@ -113,7 +113,7 @@ namespace UnitTestingExample
                     It.IsAny<EventId>(), 
                     It.Is<It.IsAnyType>((v,t) => v.ToString() == "User with username invalidUserName could not be found"), 
                     It.IsAny<NotFoundException>(), 
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)!),
                 Times.Once);
         }
         

--- a/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTestsWithMockObjects.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTestsWithMockObjects.cs
@@ -11,7 +11,7 @@ internal class UserServiceTestsWithMockObjects
     {
         // Arrange
         const string userName = "invalidUserName";
-        var sut = CreateSubject(MockUserGateWay.Create(userName));
+        var sut = CreateSubject(MockUserGateway.Create(userName));
         
         // Assert
         Assert.Throws<NotFoundException>(() => sut.GetDashboardByUserName(userName));
@@ -22,7 +22,7 @@ internal class UserServiceTestsWithMockObjects
     {
         // Arrange
         const string userName = "validUserName";
-        var sut = CreateSubject(MockUserGateWay.Create(userName, 1));
+        var sut = CreateSubject(MockUserGateway.Create(userName, 1));
 
         // Act
         var result = sut.GetDashboardByUserName(userName);
@@ -37,7 +37,7 @@ internal class UserServiceTestsWithMockObjects
         // Arrange
         const string hobby = "my-hobby";
         const string userName = "validUserName";
-        var gateway = MockUserGateWay.Create(userName,1, [hobby]);
+        var gateway = MockUserGateway.Create(userName,1, [hobby]);
         var sut = CreateSubject(gateway);
 
         // Act
@@ -52,7 +52,7 @@ internal class UserServiceTestsWithMockObjects
     {
         // Arrange
         const string userName = "validUserName";
-        var gateway = MockUserGateWay.Create(userName, 1, hobbies);
+        var gateway = MockUserGateway.Create(userName, 1, hobbies);
         var sut = CreateSubject(gateway);
 
         // Act
@@ -67,7 +67,7 @@ internal class UserServiceTestsWithMockObjects
     {
         // Arrange
         const string userName = "validUserName";
-        var gateway = MockUserGateWay.Create(userName, 1);
+        var gateway = MockUserGateway.Create(userName, 1);
         var sut = CreateSubject(gateway);
         
         // Act
@@ -83,7 +83,7 @@ internal class UserServiceTestsWithMockObjects
     public void GetDashboard_WhenNotificationsFound_ItShouldBeReturned(int? count, string expectedNotificationString)
     {
         // Arrange
-        var gateway = MockUserGateWay.Create("validUserName", 1, notificationCount: count);
+        var gateway = MockUserGateway.Create("validUserName", 1, notificationCount: count);
         var sut = CreateSubject(gateway);
         
         // Act
@@ -100,7 +100,7 @@ internal class UserServiceTestsWithMockObjects
         const string userName = "invalidUserName";
 
         var logger = MockLogger.Create("User with username invalidUserName could not be found");
-        var gateWay = MockUserGateWay.Create(userName);
+        var gateWay = MockUserGateway.Create(userName);
         var sut = CreateSubject(gateWay, logger);
             
         // Act

--- a/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTestsWithMockObjects.cs
+++ b/NETDefault/UnitTestingWithNUnit&Moq/UserServiceTestsWithMockObjects.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace UnitTestingExample;
+
+internal class UserServiceTestsWithMockObjects
+{       
+    [Test]
+    public void GetDashboard_WhenCustomerNameNotFound_ItShouldThrow()
+    {
+        // Arrange
+        const string userName = "invalidUserName";
+        var sut = CreateSubject(MockUserGateWay.Create(userName));
+        
+        // Assert
+        Assert.Throws<NotFoundException>(() => sut.GetDashboardByUserName(userName));
+    }
+
+    [Test]
+    public void GetDashboard_WhenCustomerNameFound_IdShouldBeReturned()
+    {
+        // Arrange
+        const string userName = "validUserName";
+        var sut = CreateSubject(MockUserGateWay.Create(userName, 1));
+
+        // Act
+        var result = sut.GetDashboardByUserName(userName);
+
+        // Assert
+        Assert.That(result.Contains('1'));
+    }
+
+    [Test]
+    public void GetDashboard_WhenUserFound_ItShouldGetHobbies()
+    {
+        // Arrange
+        const string hobby = "my-hobby";
+        const string userName = "validUserName";
+        var gateway = MockUserGateWay.Create(userName,1, [hobby]);
+        var sut = CreateSubject(gateway);
+
+        // Act
+        var result = sut.GetDashboardByUserName(userName);
+
+        // Assert
+        Assert.That(result.Contains(hobby));
+    }
+
+    [TestCaseSource(typeof(HobbiesTestCases))]
+    public void GetDashboard_WhenHobbiesFound_ItShouldBeReturned(string[] hobbies, string expectedHobbiesAsString)
+    {
+        // Arrange
+        const string userName = "validUserName";
+        var gateway = MockUserGateWay.Create(userName, 1, hobbies);
+        var sut = CreateSubject(gateway);
+
+        // Act
+        var result = sut.GetDashboardByUserName(userName);
+
+        // Assert
+        Assert.That(result.Contains(expectedHobbiesAsString));
+    }
+    
+    [Test]
+    public void GetDashBoard_WhenNoHobbiesAreFound_ItShouldReturnError()
+    {
+        // Arrange
+        const string userName = "validUserName";
+        var gateway = MockUserGateWay.Create(userName, 1);
+        var sut = CreateSubject(gateway);
+        
+        // Act
+        var result = sut.GetDashboardByUserName(userName);
+
+        // Assert
+        Assert.That(result.Contains(", hobbies error"));
+    }
+
+    [TestCase(null, "notification error")]
+    [TestCase(0, "0 notifications")]
+    [TestCase(1, "1 notification")]
+    public void GetDashboard_WhenNotificationsFound_ItShouldBeReturned(int? count, string expectedNotificationString)
+    {
+        // Arrange
+        var gateway = MockUserGateWay.Create("validUserName", 1, notificationCount: count);
+        var sut = CreateSubject(gateway);
+        
+        // Act
+        var result = sut.GetDashboardByUserName("validUserName");
+
+        // Assert
+        Assert.That(result.Contains(expectedNotificationString));
+    }
+        
+    [Test]
+    public void GetDashboard_WhenExceptionIsThrown_ItShouldBeLogged()
+    {
+        // Arrange
+        const string userName = "invalidUserName";
+
+        var logger = MockLogger.Create("User with username invalidUserName could not be found");
+        var gateWay = MockUserGateWay.Create(userName);
+        var sut = CreateSubject(gateWay, logger);
+            
+        // Act
+        Assume.That(() => sut.GetDashboardByUserName(userName), Throws.Exception);
+            
+        // Assert
+        logger.Verify();
+    }
+
+    private static UserService CreateSubject(IMock<IUserGateway>? gateway = null, IMock<ILogger<UserService>>? logger = null)
+    {
+        return new UserService(gateway?.Object ?? Mock.Of<IUserGateway>(), logger?.Object ?? Mock.Of<ILogger<UserService>>());
+    }
+}


### PR DESCRIPTION
Instead of using setup in your tests which can become quite complex, for example when using Extension methods !Looking at you logger! this example uses mock objects to handle the setup. To make sure we hide as much details as possible and loosely couple the tests to Moq, we also use a factory method instead of the constructor as this can give more flexibility if for example changing mocking library or removing the use of such library entirely.

The only real Moq dependency we have in this example is in the factory method `CreateSubject(...) as we need an .Object call to get an instance of the mocked interface.