### PR TITLE
Update Directory.Build.props with SatelliteResourceLanguages default

### DIFF
--- a/Standards/Configuration/Directory.Build.props
+++ b/Standards/Configuration/Directory.Build.props
@@ -3,6 +3,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8623;CS8624;CS8625;CS8628;CS8629;CS8631;CS8634;IDE0130;NU1605;CS8765;CS8677;VSTHRD200</WarningsAsErrors>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages> <!-- Avoids resource files from packages in bin output; remove or specify used locales when using resource translations -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">


### PR DESCRIPTION
Configuration to avoid unused resources from nuget packages

https://andrewlock.net/disabling-localized-satellite-assemblies-during-dotnet-publish/